### PR TITLE
Fix missing ifdef SYNTAX_HIGHLIGHTING for file commands in edit.cpp

### DIFF
--- a/src/edit.cpp
+++ b/src/edit.cpp
@@ -674,7 +674,9 @@ void Editor::enableFileCommands(bool enable) {
     _cmdLineNumbers->setEnabled(enable);
     //_cmdFormatting->setEnabled(enable);
     _cmdBrackets->setEnabled(enable);
+#ifdef SYNTAX_HIGHLIGHTING
     _cmdSyntaxHighlight->setEnabled(enable);
+#endif
     _cmdTileVert->setEnabled(enable);
     _cmdTileHorz->setEnabled(enable);
     _cmdTileFull->setEnabled(enable);


### PR DESCRIPTION
Just a small fix for a segfault when syntax highlighting is not enabled at build time.