### PR TITLE
meson.build: Install manpages

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -38,4 +38,7 @@ else
   endif
 endif
 
+install_man('manpages/chr.1')
+install_man('manpages/chr.de.1', locale: 'de')
+
 subdir('src')


### PR DESCRIPTION
Maybe this could be “simpler” than explicitly listing every file (i.&#8239;e., the two of them) and splitting them by locale automatically, but that’s probably for when there are more translations than that.