### PR TITLE
meson.build: Register tests executable

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -106,8 +106,9 @@ executable('chr', main,
   link_with: editor_lib,
   dependencies : [qt5_dep, tuiwidgets_dep, posixsignalmanager_dep, syntax_dep])
 
-executable('tests', tests,
+tests_bin = executable('tests', tests,
   qt5.preprocess(moc_headers: tests_headers, moc_sources: tests,
   include_directories: include_directories('.')),
   link_with: editor_lib,
   dependencies : [qt5_dep, tuiwidgets_dep, posixsignalmanager_dep, syntax_dep, catch2_dep])
+test('tests', tests_bin, workdir: meson.current_build_dir())


### PR DESCRIPTION
This enables running the tests directly with `meson test`.